### PR TITLE
2026-02-11 alert-fix-13

### DIFF
--- a/C#/EU.CqrXs/Console/Program.cs
+++ b/C#/EU.CqrXs/Console/Program.cs
@@ -3,6 +3,8 @@ using EU.CqrXs.Crypt.EnDeCoding;
 using EU.CqrXs.Crypt.Hash;
 using EU.CqrXs.Util;
 using EU.CqrXs.Zip;
+using Org.BouncyCastle.Crypto;
+using System;
 using System.Text;
 
 namespace EU.CqrXs.Console
@@ -10,7 +12,7 @@ namespace EU.CqrXs.Console
 
 
     /// <summary>
-    /// Console app pipe for crypt/decrypt zip/unzip encode/decode md5sum/shaSum
+    /// Console app pipe for crypt/decrypt zip/unzip encode/decode md5sum/shaSum     
     /// 
     /// EU.CqrXs.Console.Program 
     /// -i | --inFile= | --inText={string|EnviromentVariable} | --inStd    
@@ -28,6 +30,23 @@ namespace EU.CqrXs.Console
     /// -D | --Decrypt 
     /// -? | --gethelp
     /// </summary>
+    /// <remarks>
+    /// <list type="bullet">
+    /// <listheader>code changes</listheader>
+    /// <item>
+    /// 2026-02-11 alert-fix-13 changed mode from "ECB" to "CFB"     
+    /// Reason: Git security scans
+    /// consequences: no more fully deterministic math bijective proper symmertric cipher en-/decryption in pipe
+    /// fixed attacks: not so easy REPLY attacks with binary format header and heuristic key collection
+    /// </item>
+    /// <item>
+    /// 2026-mm-dd [enter pull request name here] [enter what you did here]
+    /// Reason: [enter a senseful reason]
+    /// consequences: [describe most impactful consequences of bugfix or code change request]
+    /// fixed [vulnerability, code smell]: [Describe understandable precise in 1-2 setences]
+    /// </item>
+    /// </list>
+    /// </remarks>
     internal class Program
     {
         const string BATCH_FILE_TEST = "Console_Test.bat";

--- a/C#/EU.CqrXs/Crypt/Cipher/CipherMode2.cs
+++ b/C#/EU.CqrXs/Crypt/Cipher/CipherMode2.cs
@@ -6,6 +6,26 @@ using System.Security.Cryptography;
 namespace EU.CqrXs.Crypt.Cipher
 {
 
+    /// <summary>
+    /// CipherMode2 enumeration type for more cipher mode as found in standard <see cref="System.Security.Cryptography.CipherMode"/>
+    /// </summary>
+    /// <remarks>
+    /// <list type="bullet">
+    /// <listheader>code changes</listheader>
+    /// <item>
+    /// 2026-02-11 alert-fix-13 changed mode from "ECB" to "CFB"     
+    /// Reason: Git security scans
+    /// consequences: no more fully deterministic math bijective proper symmertric cipher en-/decryption in pipe
+    /// fixed attacks: not so easy REPLY attacks with binary format header and heuristic key collection
+    /// </item>
+    /// <item>
+    /// 2026-mm-dd [enter pull request name here] [enter what you did here]
+    /// Reason: [enter a senseful reason]
+    /// consequences: [describe most impactful consequences of bugfix or code change request]
+    /// fixed [vulnerability, code smell]: [Describe understandable precise in 1-2 setences]
+    /// </item>
+    /// </list>
+    /// </remarks>
     [Serializable]
     [DefaultValue("CFB")]
     public enum CipherMode2 : byte
@@ -44,6 +64,26 @@ namespace EU.CqrXs.Crypt.Cipher
 
     }
 
+    /// <summary>
+    /// Extension methods for <see cref="CipherMode2">enum CipherMode2</see>
+    /// </summary>
+    /// <remarks>
+    /// <list type="bullet">
+    /// <listheader>code changes</listheader>
+    /// <item>
+    /// 2026-02-11 alert-fix-13 changed mode from "ECB" to "CFB"     
+    /// Reason: Git security scans
+    /// consequences: no more fully deterministic math bijective proper symmertric cipher en-/decryption in pipe
+    /// fixed attacks: not so easy REPLY attacks with binary format header and heuristic key collection
+    /// </item>
+    /// <item>
+    /// 2026-mm-dd [enter pull request name here] [enter what you did here]
+    /// Reason: [enter a senseful reason]
+    /// consequences: [describe most impactful consequences of bugfix or code change request]
+    /// fixed [vulnerability, code smell]: [Describe understandable precise in 1-2 setences]
+    /// </item>
+    /// </list>
+    /// </remarks>
     public static partial class CipherModeExtensions
     {
 

--- a/C#/EU.CqrXs/Crypt/Cipher/CipherPipe.cs
+++ b/C#/EU.CqrXs/Crypt/Cipher/CipherPipe.cs
@@ -16,6 +16,23 @@ namespace EU.CqrXs.Crypt.Cipher
     /// <summary>
     /// Provides a simple crypt pipe for <see cref="CipherEnum"/>
     /// </summary>
+    /// <remarks>
+    /// <list type="bullet">
+    /// <listheader>code changes</listheader>
+    /// <item>
+    /// 2026-02-11 alert-fix-13 changed mode from "ECB" to "CFB"     
+    /// Reason: Git security scans
+    /// consequences: no more fully deterministic math bijective proper symmertric cipher en-/decryption in pipe
+    /// fixed attacks: not so easy REPLY attacks with binary format header and heuristic key collection
+    /// </item>
+    /// <item>
+    /// 2026-mm-dd [enter pull request name here] [enter what you did here]
+    /// Reason: [enter a senseful reason]
+    /// consequences: [describe most impactful consequences of bugfix or code change request]
+    /// fixed [vulnerability, code smell]: [Describe understandable precise in 1-2 setences]
+    /// </item>
+    /// </list>
+    /// </remarks>
     public class CipherPipe
     {
 

--- a/C#/EU.CqrXs/Crypt/Cipher/CryptParams.cs
+++ b/C#/EU.CqrXs/Crypt/Cipher/CryptParams.cs
@@ -9,6 +9,23 @@ namespace EU.CqrXs.Crypt.Cipher
     /// <summary>
     /// CryptParams parameters for encryption algorithm engine
     /// </summary>
+    /// <remarks>
+    /// <list type="bullet">
+    /// <listheader>code changes</listheader>
+    /// <item>
+    /// 2026-02-11 alert-fix-13 changed mode from "ECB" to "CFB"     
+    /// Reason: Git security scans
+    /// consequences: no more fully deterministic math bijective proper symmertric cipher en-/decryption in pipe
+    /// fixed attacks: not so easy REPLY attacks with binary format header and heuristic key collection
+    /// </item>
+    /// <item>
+    /// 2026-mm-dd [enter pull request name here] [enter what you did here]
+    /// Reason: [enter a senseful reason]
+    /// consequences: [describe most impactful consequences of bugfix or code change request]
+    /// fixed [vulnerability, code smell]: [Describe understandable precise in 1-2 setences]
+    /// </item>
+    /// </list>
+    /// </remarks>
     public class CryptParams
     {
 

--- a/C#/EU.CqrXs/Crypt/Cipher/Symmetric/AesNet.cs
+++ b/C#/EU.CqrXs/Crypt/Cipher/Symmetric/AesNet.cs
@@ -11,6 +11,23 @@ namespace EU.CqrXs.Crypt.Cipher.Symmetric
     /// AesNet native .Net AesCng without bouncy castle
     /// <see href="https://learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.aescng?view=net-8.0" />
     /// </summary>
+    /// <remarks>
+    /// <list type="bullet">
+    /// <listheader>code changes</listheader>
+    /// <item>
+    /// 2026-02-11 alert-fix-13 changed mode from "ECB" to "CFB"     
+    /// Reason: Git security scans
+    /// consequences: no more fully deterministic math bijective proper symmertric cipher en-/decryption in pipe
+    /// fixed attacks: not so easy REPLY attacks with binary format header and heuristic key collection
+    /// </item>
+    /// <item>
+    /// 2026-mm-dd [enter pull request name here] [enter what you did here]
+    /// Reason: [enter a senseful reason]
+    /// consequences: [describe most impactful consequences of bugfix or code change request]
+    /// fixed [vulnerability, code smell]: [Describe understandable precise in 1-2 setences]
+    /// </item>
+    /// </list>
+    /// </remarks>
     public class AesNet
     {
 
@@ -32,11 +49,17 @@ namespace EU.CqrXs.Crypt.Cipher.Symmetric
 
         #region ctor
 
+        /// <summary>
+        /// static AesNet constructor
+        /// </summary>
         static AesNet()
         {
             AesKeyLen = 32;
         }
 
+        /// <summary>
+        /// standard parameterless ctor of AesNet
+        /// </summary>
         public AesNet() : this(Convert.FromBase64String(Constants.AES_KEY), Convert.FromBase64String(Constants.AES_IV)) { }
 
         public AesNet(string key, string hash, EncodingType encodeType = EncodingType.None, 
@@ -71,6 +94,10 @@ namespace EU.CqrXs.Crypt.Cipher.Symmetric
             AesAlgo.Padding = PaddingMode.ISO10126;
         }
 
+        /// <summary>
+        /// AesNet constructor with default crypto parameters
+        /// </summary>
+        /// <param name="cparams"></param>
         public AesNet(CryptParams cparams)
         {
             if (string.IsNullOrEmpty(cparams.Key) && string.IsNullOrEmpty(cparams.Hash))

--- a/C#/EU.CqrXs/Crypt/Cipher/Symmetric/CryptBounceCastle.cs
+++ b/C#/EU.CqrXs/Crypt/Cipher/Symmetric/CryptBounceCastle.cs
@@ -16,6 +16,23 @@ namespace EU.CqrXs.Crypt.Cipher.Symmetric
     /// <see cref="Org.BouncyCastle.Crypto.Engines.SkipjackEngine"/>, <see cref="Org.BouncyCastle.Crypto.Engines.TeaEngine"/>, <see cref="Org.BouncyCastle.Crypto.Engines.TnepresEngine"/>,
     /// <see cref="Org.BouncyCastle.Crypto.Engines.XteaEngine"/>, ... and many more
     /// </summary>
+    /// <remarks>
+    /// <list type="bullet">
+    /// <listheader>code changes</listheader>
+    /// <item>
+    /// 2026-02-11 alert-fix-13 changed mode from "ECB" to "CFB"     
+    /// Reason: Git security scans
+    /// consequences: no more fully deterministic math bijective proper symmertric cipher en-/decryption in pipe
+    /// fixed attacks: not so easy REPLY attacks with binary format header and heuristic key collection
+    /// </item>
+    /// <item>
+    /// 2026-mm-dd [enter pull request name here] [enter what you did here]
+    /// Reason: [enter a senseful reason]
+    /// consequences: [describe most impactful consequences of bugfix or code change request]
+    /// fixed [vulnerability, code smell]: [Describe understandable precise in 1-2 setences]
+    /// </item>
+    /// </list>
+    /// </remarks>
     public class CryptBounceCastle
     {
 

--- a/C#/EU.CqrXs/Crypt/Cipher/Symmetric/Des3Net.cs
+++ b/C#/EU.CqrXs/Crypt/Cipher/Symmetric/Des3Net.cs
@@ -11,6 +11,23 @@ namespace EU.CqrXs.Crypt.Cipher.Symmetric
     /// <see href="https://learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.tripledes.-ctor?view=net-8.0" />
     /// <seealso href="https://www.c-sharpcorner.com/article/tripledes-encryption-and-decryption-in-c-sharp/" />
     /// </summary>
+    /// <remarks>
+    /// <list type="bullet">
+    /// <listheader>code changes</listheader>
+    /// <item>
+    /// 2026-02-11 alert-fix-13 changed mode from "ECB" to "CFB"     
+    /// Reason: Git security scans
+    /// consequences: no more fully deterministic math bijective proper symmertric cipher en-/decryption in pipe
+    /// fixed attacks: not so easy REPLY attacks with binary format header and heuristic key collection
+    /// </item>
+    /// <item>
+    /// 2026-mm-dd [enter pull request name here] [enter what you did here]
+    /// Reason: [enter a senseful reason]
+    /// consequences: [describe most impactful consequences of bugfix or code change request]
+    /// fixed [vulnerability, code smell]: [Describe understandable precise in 1-2 setences]
+    /// </item>
+    /// </list>
+    /// </remarks>
     public class Des3Net
     {
 

--- a/C#/EU.CqrXs/Crypt/Cipher/Symmetric/SecureCipherPipe.cs
+++ b/C#/EU.CqrXs/Crypt/Cipher/Symmetric/SecureCipherPipe.cs
@@ -14,6 +14,23 @@ namespace EU.CqrXs.Crypt.Cipher.Symmetric
     /// <summary>
     /// Provides a simple crypt pipe for <see cref="CipherEnum"/>
     /// </summary>
+    /// <remarks>
+    /// <list type="bullet">
+    /// <listheader>code changes</listheader>
+    /// <item>
+    /// 2026-02-11 alert-fix-13 changed mode from "ECB" to "CFB"     
+    /// Reason: Git security scans
+    /// consequences: no more fully deterministic math bijective proper symmertric cipher en-/decryption in pipe
+    /// fixed attacks: not so easy REPLY attacks with binary format header and heuristic key collection
+    /// </item>
+    /// <item>
+    /// 2026-mm-dd [enter pull request name here] [enter what you did here]
+    /// Reason: [enter a senseful reason]
+    /// consequences: [describe most impactful consequences of bugfix or code change request]
+    /// fixed [vulnerability, code smell]: [Describe understandable precise in 1-2 setences]
+    /// </item>
+    /// </list>
+    /// </remarks>
     public class SecureCipherPipe
     {
 

--- a/C#/EU.CqrXs/Crypt/Msg/CContact.cs
+++ b/C#/EU.CqrXs/Crypt/Msg/CContact.cs
@@ -16,7 +16,7 @@ namespace EU.CqrXs.Crypt.Msg
     /// <summary>
     /// CContact derived from <see cref="CMsg"/> is a container for any Google or Outlook contact
     /// TODO: refactor it!
-    /// </summary>
+    /// </summary>    
     [Serializable]
     public class CContact : CMsg, IMsgAble
     {

--- a/C#/EU.CqrXs/Properties/EU.CqrXs.xml
+++ b/C#/EU.CqrXs/Properties/EU.CqrXs.xml
@@ -455,6 +455,22 @@
             <see href="https://learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.aescng?view=net-8.0" />
             </summary>
         </member>
+        <member name="M:EU.CqrXs.Crypt.Cipher.Symmetric.AesNet.#cctor">
+            <summary>
+            static AesNet constructor
+            </summary>
+        </member>
+        <member name="M:EU.CqrXs.Crypt.Cipher.Symmetric.AesNet.#ctor">
+            <summary>
+            standard parameterless ctor of AesNet
+            </summary>
+        </member>
+        <member name="M:EU.CqrXs.Crypt.Cipher.Symmetric.AesNet.#ctor(EU.CqrXs.Crypt.Cipher.CryptParams)">
+            <summary>
+            AesNet constructor with default crypto parameters
+            </summary>
+            <param name="cparams"></param>
+        </member>
         <member name="M:EU.CqrXs.Crypt.Cipher.Symmetric.AesNet.Encrypt(System.Byte[])">
             <summary>
             AES Encrypt by using RijndaelManaged

--- a/C#/EU.CqrXs/Spooler/Program.cs
+++ b/C#/EU.CqrXs/Spooler/Program.cs
@@ -13,6 +13,23 @@ namespace EU.CqrXs.Spooler
     /// <summary>
     /// OptEnum different option types
     /// </summary>
+    /// <remarks>
+    /// <list type="bullet">
+    /// <listheader>code changes</listheader>
+    /// <item>
+    /// 2026-02-11 alert-fix-13 changed mode from "ECB" to "CFB"     
+    /// Reason: Git security scans
+    /// consequences: no more fully deterministic math bijective proper symmertric cipher en-/decryption in pipe
+    /// fixed attacks: not so easy REPLY attacks with binary format header and heuristic key collection
+    /// </item>
+    /// <item>
+    /// 2026-mm-dd [enter pull request name here] [enter what you did here]
+    /// Reason: [enter a senseful reason]
+    /// consequences: [describe most impactful consequences of bugfix or code change request]
+    /// fixed [vulnerability, code smell]: [Describe understandable precise in 1-2 setences]
+    /// </item>
+    /// </list>
+    /// </remarks>
     public enum OptSpoolEnum
     {
         Usage = 0x0,

--- a/android/CipherPipe/app/src/main/java/eu/cqrxs/cipherpipe/crypt/cipher/CryptBounceCastle.java
+++ b/android/CipherPipe/app/src/main/java/eu/cqrxs/cipherpipe/crypt/cipher/CryptBounceCastle.java
@@ -69,7 +69,11 @@ public class CryptBounceCastle  {
 
 
     /**
-     * parameterless default constructor
+     * CryptBounceCastle parameterless default constructor
+     * 2026-02-11: changed mode from "ECB" to "CFB"     
+     * Reason: Git security scans
+     * consequences: no more fully deterministic math bijective proper symmertric cipher en-/decryption in pipe
+     * fixed attacks: not so easy REPLY attacks with binary format header and heuristic key collection
      */
     public CryptBounceCastle()  {
         CryptoBlockCipher = null;


### PR DESCRIPTION
Changed default CipherMode and CipherMode2 from "ECB" to "CFB"

Reason: Git security scans

consequences: no more fully deterministic math bijective proper symmertric cipher en-/decryption in pipe

fixed attacks: not so easy REPLY attacks with binary format header and heuristic key collection