### PR TITLE
Mark project as obsolete and link to CryptPupe

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-# 8-staged symmetric block cipher pipeline 
+# 8-staged symmetric block cipher pipeline (obsolete)
+
+## new repository is [CryptPupe](https://github.com/heinrichelsigan/CryptPipe)
+
 
 An eight staged symmetric block cipher crypto pipeline to improve advanced encryption standard based on meta DES, 3DES with P-Box S-Box.
 


### PR DESCRIPTION
Updated README to mark the project as obsolete and link to the new repository.